### PR TITLE
Restore support for old data schema

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -8,11 +8,12 @@ class CourseActivityByWeek(models.Model):
 
     class Meta(object):
         db_table = 'course_activity'
+        index_together = [['course_id', 'activity_type']]
 
-    course_id = models.CharField(max_length=255)
+    course_id = models.CharField(db_index=True, max_length=255)
     interval_start = models.DateTimeField()
     interval_end = models.DateTimeField()
-    activity_type = models.CharField(db_index=True, max_length=255)
+    activity_type = models.CharField(db_index=True, max_length=255, db_column='label')
     count = models.IntegerField()
 
     @classmethod

--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -24,13 +24,13 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
         interval_start = '2014-05-24T00:00:00Z'
         interval_end = '2014-06-01T00:00:00Z'
         G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
-          activity_type='posted_forum', count=100)
+          activity_type='POSTED_FORUM', count=100)
         G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
-          activity_type='attempted_problem', count=200)
+          activity_type='ATTEMPTED_PROBLEM', count=200)
         G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
-          activity_type='any', count=300)
+          activity_type='ACTIVE', count=300)
         G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
-          activity_type='played_video', count=400)
+          activity_type='PLAYED_VIDEO', count=400)
 
     def test_activity(self):
         response = self.authenticated_get('/api/v0/courses/{0}/recent_activity'.format(self.course_id))
@@ -43,10 +43,11 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
             'course_id': 'edX/DemoX/Demo_Course',
             'interval_start': datetime.datetime(2014, 5, 24, 0, 0, tzinfo=pytz.utc),
             'interval_end': datetime.datetime(2014, 6, 1, 0, 0, tzinfo=pytz.utc),
-            'activity_type': 'any',
+            'activity_type': 'ACTIVE',
             'count': 300,
         }
         default.update(kwargs)
+        default['activity_type'] = default['activity_type'].upper()
         return default
 
     def test_activity_auth(self):
@@ -78,6 +79,13 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
     def test_missing_course_id(self):
         response = self.authenticated_get('/api/v0/courses/recent_activity')
         self.assertEquals(response.status_code, 404)
+
+    def test_label_parameter(self):
+        activity_type = 'played_video'
+        response = self.authenticated_get('/api/v0/courses/{0}/recent_activity?label={1}'.format(
+            self.course_id, activity_type))
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.data, self.get_activity_record(activity_type=activity_type, count=400))
 
 
 # pylint: disable=no-member

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -38,12 +38,37 @@ class CourseActivityMostRecentWeekView(generics.RetrieveAPIView):
     """
 
     serializer_class = serializers.CourseActivityByWeekSerializer
+    DEFAULT_ACTIVITY_TYPE = 'ACTIVE'
+
+    def _format_activity_type(self, activity_type):
+        """
+        Modify the activity type parameter for use with our data.
+
+        Arguments:
+            activity_type (str): String to be formatted
+        """
+        activity_type = activity_type.upper()
+
+        if activity_type == 'ANY':
+            activity_type = self.DEFAULT_ACTIVITY_TYPE
+        return activity_type
+
+    def _get_activity_type(self):
+        """ Retrieve the activity type from the query string. """
+
+        # Support the old label param
+        activity_type = self.request.QUERY_PARAMS.get('label', None)
+
+        activity_type = activity_type or self.request.QUERY_PARAMS.get('activity_type', self.DEFAULT_ACTIVITY_TYPE)
+        activity_type = self._format_activity_type(activity_type)
+
+        return activity_type
 
     def get_object(self, queryset=None):
         """Select the activity report for the given course and activity type."""
+
         course_id = self.kwargs.get('course_id')
-        activity_type = self.request.QUERY_PARAMS.get('activity_type', 'any')
-        activity_type = activity_type.lower()
+        activity_type = self._get_activity_type()
 
         try:
             return models.CourseActivityByWeek.get_most_recent(course_id, activity_type)


### PR DESCRIPTION
This change should allow us to accept the old database schema while maintaining the newer client schema.
- Changed activity_type column to label
- Using uppercase activity_type
