### PR TITLE
Returning both alpha2 and alpha3 country codes

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from django.db import models
 from iso3166 import countries
 
@@ -97,16 +96,15 @@ class ProblemResponseAnswerDistribution(models.Model):
     created = models.DateTimeField(auto_now_add=True, db_column='created')
 
 
-Country = namedtuple('Country', 'name code')
-
-
 class CourseEnrollmentByCountry(BaseCourseEnrollment):
     country_code = models.CharField(max_length=255, null=False, db_column='country_code')
 
     @property
     def country(self):
-        country = countries.get(self.country_code)
-        return Country(country.name, country.alpha2)
+        """
+        Returns a Country object representing the country in this model's country_code.
+        """
+        return countries.get(self.country_code)
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_location_current'

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -66,7 +66,15 @@ class CourseEnrollmentDailySerializer(BaseCourseEnrollmentModelSerializer):
 
 
 class CountrySerializer(serializers.Serializer):
-    code = serializers.CharField()
+    """
+    Serialize country to an object with fields for the complete country name
+    and the ISO-3166 two- and three-digit codes.
+
+    Some downstream consumers need two-digit codes, others need three. Both are provided to avoid the need
+    for conversion.
+    """
+    alpha2 = serializers.CharField()
+    alpha3 = serializers.CharField()
     name = serializers.CharField()
 
 

--- a/analytics_data_api/v0/tests/test_models.py
+++ b/analytics_data_api/v0/tests/test_models.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from django_dynamic_fixture import G
+from iso3166 import countries
 
 from analytics_data_api.v0 import models
 
@@ -16,17 +17,9 @@ class EducationLevelTests(TestCase):
                          "{0} - {1}".format(short_name, name))
 
 
-class CountryTests(TestCase):
-    # pylint: disable=no-member
-    def test_attributes(self):
-        country = models.Country('Canada', 'CA')
-        self.assertEqual(country.code, 'CA')
-        self.assertEqual(country.name, 'Canada')
-
-
 class CourseEnrollmentByCountryTests(TestCase):
     def test_country(self):
-        country = models.Country('United States', 'US')
-        instance = G(models.CourseEnrollmentByCountry,
-                     country_code=country.code)
+        country = countries.get('US')
+        self.assertEqual(country.alpha2, 'US')
+        instance = G(models.CourseEnrollmentByCountry, country_code=country.alpha2)
         self.assertEqual(instance.country, country)

--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -23,13 +23,17 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
         self.course_id = 'edX/DemoX/Demo_Course'
         interval_start = '2014-05-24T00:00:00Z'
         interval_end = '2014-06-01T00:00:00Z'
-        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
+        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start,
+          interval_end=interval_end,
           activity_type='POSTED_FORUM', count=100)
-        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
+        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start,
+          interval_end=interval_end,
           activity_type='ATTEMPTED_PROBLEM', count=200)
-        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
+        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start,
+          interval_end=interval_end,
           activity_type='ACTIVE', count=300)
-        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start, interval_end=interval_end,
+        G(models.CourseActivityByWeek, course_id=self.course_id, interval_start=interval_start,
+          interval_end=interval_end,
           activity_type='PLAYED_VIDEO', count=400)
 
     def test_activity(self):
@@ -109,7 +113,8 @@ class CourseEnrollmentViewTestCase(object):
         self.assertEquals(response.status_code, 200)
 
         # Validate the data is correct and sorted chronologically
-        expected = self.get_expected_response(*self.model.objects.filter(date=self.date).order_by('date', *self.order_by))  # pylint: disable=line-too-long
+        expected = self.get_expected_response(*self.model.objects.filter(date=self.date).order_by('date',
+                                                                                                  *self.order_by))  # pylint: disable=line-too-long
         self.assertEquals(response.data, expected)
 
     def test_get_csv(self):
@@ -288,10 +293,11 @@ class CourseEnrollmentByLocationViewTests(TestCaseWithAuthentication, CourseEnro
     model = models.CourseEnrollmentByCountry
 
     def get_expected_response(self, *args):
-        args = sorted(args, key=lambda item: (item.date, item.course_id, item.country.code))
+        args = sorted(args, key=lambda item: (item.date, item.course_id, item.country.alpha3))
         return [
             {'course_id': str(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
-             'country': {'code': ce.country.code, 'name': ce.country.name}} for ce in args]
+             'country': {'alpha2': ce.country.alpha2, 'alpha3': ce.country.alpha3, 'name': ce.country.name}} for ce in
+            args]
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This replaces the code field with two fields, alpha2 and alpha3.

@dsjen @rocha 
