### PR TITLE
Upgraded Django and South

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
-Django==1.6.5 						# BSD License
+Django==1.6.6 						# BSD License
 Markdown==2.4.1 					# BSD
-South==0.8.1 						# APache License
+South==1.0   						# Apache License
 django-model-utils==1.4.0 			# BSD
 djangorestframework==2.3.5			# BSD
 ipython==2.1.0						# BSD


### PR DESCRIPTION
Django 1.6.6 includes security fixes. South 1.0 adds support for third-party apps that support Django 1.7 and <1.7.

@rocha @dsjen @mulby 
