### PR TITLE
Excluding non-ISO-3166-compliant data

### DIFF
--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -104,7 +104,11 @@ class CourseEnrollmentByCountry(BaseCourseEnrollment):
         """
         Returns a Country object representing the country in this model's country_code.
         """
-        return countries.get(self.country_code)
+        try:
+            return countries.get(self.country_code)
+        except (KeyError, ValueError):
+            # Country code is not valid ISO-3166
+            return None
 
     class Meta(BaseCourseEnrollment.Meta):
         db_table = 'course_enrollment_location_current'

--- a/analytics_data_api/v0/tests/test_models.py
+++ b/analytics_data_api/v0/tests/test_models.py
@@ -23,3 +23,13 @@ class CourseEnrollmentByCountryTests(TestCase):
         self.assertEqual(country.alpha2, 'US')
         instance = G(models.CourseEnrollmentByCountry, country_code=country.alpha2)
         self.assertEqual(instance.country, country)
+
+    def test_invalid_country(self):
+        instance = G(models.CourseEnrollmentByCountry, country_code='')
+        self.assertIsNone(instance.country)
+
+        instance = G(models.CourseEnrollmentByCountry, country_code='A1')
+        self.assertIsNone(instance.country)
+
+        instance = G(models.CourseEnrollmentByCountry, country_code='GobbledyGoop!')
+        self.assertIsNone(instance.country)

--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -293,6 +293,7 @@ class CourseEnrollmentByLocationViewTests(TestCaseWithAuthentication, CourseEnro
     model = models.CourseEnrollmentByCountry
 
     def get_expected_response(self, *args):
+        args = [arg for arg in args if arg.country_code not in ['', 'A1', 'A2', 'AP', 'EU', 'O1', 'UNKNOWN']]
         args = sorted(args, key=lambda item: (item.date, item.course_id, item.country.alpha3))
         return [
             {'course_id': str(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
@@ -307,3 +308,9 @@ class CourseEnrollmentByLocationViewTests(TestCaseWithAuthentication, CourseEnro
         G(cls.model, course_id=cls.course_id, country_code='US', count=455, date=cls.date)
         G(cls.model, course_id=cls.course_id, country_code='CA', count=356, date=cls.date)
         G(cls.model, course_id=cls.course_id, country_code='IN', count=12, date=cls.date - datetime.timedelta(days=29))
+        G(cls.model, course_id=cls.course_id, country_code='', count=356, date=cls.date)
+        G(cls.model, course_id=cls.course_id, country_code='A1', count=1, date=cls.date)
+        G(cls.model, course_id=cls.course_id, country_code='A2', count=2, date=cls.date)
+        G(cls.model, course_id=cls.course_id, country_code='AP', count=1, date=cls.date)
+        G(cls.model, course_id=cls.course_id, country_code='EU', count=4, date=cls.date)
+        G(cls.model, course_id=cls.course_id, country_code='O1', count=7, date=cls.date)

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -214,3 +214,14 @@ class CourseEnrollmentByLocationView(BaseCourseEnrollmentView):
 
     serializer_class = serializers.CourseEnrollmentByCountrySerializer
     model = models.CourseEnrollmentByCountry
+
+    def get_queryset(self):
+        queryset = super(CourseEnrollmentByLocationView, self).get_queryset()
+
+        # Remove all items where country is None
+        items = [item for item in queryset.all() if item.country is not None]
+
+        # Note: We are returning a list, instead of a queryset. This is
+        # acceptable since the consuming code simply expects the returned
+        # value to be iterable, not necessarily a queryset.
+        return items


### PR DESCRIPTION
The data in the DB uses Maxmind's data format (which includes a few additional codes in addition to the standard ISO-3166 codes). This data is not consumable by the API and will now be excluded when querying for geolocation data.

@dsjen @rocha @mulby
