### PR TITLE
Added additional test coverage

### DIFF
--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -41,6 +41,12 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data, self.get_activity_record())
 
+    def assertValidActivityResponse(self, activity_type, count):
+        response = self.authenticated_get('/api/v0/courses/{0}/recent_activity?activity_type={1}'.format(
+            self.course_id, activity_type))
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.data, self.get_activity_record(activity_type=activity_type, count=count))
+
     @staticmethod
     def get_activity_record(**kwargs):
         default = {
@@ -63,12 +69,12 @@ class CourseActivityLastWeekTest(TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data, self.get_activity_record())
 
+    def test_any_activity(self):
+        self.assertValidActivityResponse('ANY', 300)
+        self.assertValidActivityResponse('any', 300)
+
     def test_video_activity(self):
-        activity_type = 'played_video'
-        response = self.authenticated_get('/api/v0/courses/{0}/recent_activity?activity_type={1}'.format(
-            self.course_id, activity_type))
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.data, self.get_activity_record(activity_type=activity_type, count=400))
+        self.assertValidActivityResponse('played_video', 400)
 
     def test_unknown_activity(self):
         activity_type = 'missing_activity_type'

--- a/analyticsdataserver/tests.py
+++ b/analyticsdataserver/tests.py
@@ -8,6 +8,8 @@ from django.test.utils import override_settings
 
 import mock
 from rest_framework.authtoken.models import Token
+from analytics_data_api.v0.models import CourseEnrollmentDaily, CourseEnrollmentByBirthYear
+from analyticsdataserver.router import AnalyticsApiRouter
 
 
 class TestCaseWithAuthentication(TestCase):
@@ -83,3 +85,15 @@ class OperationalEndpointsTest(TestCaseWithAuthentication):
             # This would normally return UNAVAILABLE, however we have deleted the settings so it will use the default
             # connection which should be OK.
             self.assert_database_health('OK')
+
+
+class AnalyticsApiRouterTests(TestCase):
+    def setUp(self):
+        self.router = AnalyticsApiRouter()
+
+    def test_allow_relation(self):
+        """
+        Relations should only be allowed for objects contained within the same database.
+        """
+        self.assertFalse(self.router.allow_relation(CourseEnrollmentDaily, User))
+        self.assertTrue(self.router.allow_relation(CourseEnrollmentDaily, CourseEnrollmentByBirthYear))


### PR DESCRIPTION
- Testing recent activity resource for capitalized and un-capitalized variations of "ANY"
- Added test for DB router

@dsjen @rocha
