### PR TITLE
Grouping and Returning Unknown Locations

### DIFF
--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -48,12 +48,13 @@ class Command(BaseCommand):
             'doctorate': 0.0470
         }
         country_ratios = {
-            'US': 0.34,
+            'US': 0.33,
             'GH': 0.12,
             'IN': 0.10,
             'CA': 0.14,
             'CN': 0.22,
-            'DE': 0.08
+            'DE': 0.08,
+            'UNKNOWN': 0.01
         }
 
         # Generate birth year ratios

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from iso3166 import countries
+from iso3166 import countries, Country
 
 
 class CourseActivityWeekly(models.Model):
@@ -99,6 +99,7 @@ class ProblemResponseAnswerDistribution(models.Model):
 
 
 class CourseEnrollmentByCountry(BaseCourseEnrollment):
+    UNKNOWN_COUNTRY_CODE = 'UNKNOWN'
     country_code = models.CharField(max_length=255, null=False, db_column='country_code')
 
     @property
@@ -107,6 +108,9 @@ class CourseEnrollmentByCountry(BaseCourseEnrollment):
         Returns a Country object representing the country in this model's country_code.
         """
         try:
+            if self.country_code == self.UNKNOWN_COUNTRY_CODE:
+                return Country(u"UNKNOWN", None, None, None)
+
             return countries.get(self.country_code)
         except (KeyError, ValueError):
             # Country code is not valid ISO-3166

--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -323,12 +323,26 @@ class CourseEnrollmentByLocationViewTests(CourseEnrollmentViewTestCaseMixin, Tes
     model = models.CourseEnrollmentByCountry
 
     def format_as_response(self, *args):
+        unknown = {'course_id': None, 'count': 0, 'date': None,
+                   'country': {'alpha2': None, 'alpha3': None, 'name': u'UNKNOWN'}}
+
+        for arg in args:
+            if not arg.country:
+                unknown['course_id'] = arg.course_id
+                unknown['date'] = arg.date.strftime(settings.DATE_FORMAT)
+                unknown['count'] += arg.count
+
         args = [arg for arg in args if arg.country_code not in ['', 'A1', 'A2', 'AP', 'EU', 'O1', 'UNKNOWN']]
         args = sorted(args, key=lambda item: (item.date, item.course_id, item.country.alpha3))
-        return [
+        response = [
             {'course_id': str(ce.course_id), 'count': ce.count, 'date': ce.date.strftime(settings.DATE_FORMAT),
              'country': {'alpha2': ce.country.alpha2, 'alpha3': ce.country.alpha3, 'name': ce.country.name}} for ce in
             args]
+
+        # Unknown comes last
+        response.append(unknown)
+
+        return response
 
     def setUp(self):
         super(CourseEnrollmentByLocationViewTests, self).setUp()


### PR DESCRIPTION
Enrollment-location rows without a valid ISO-3166 country code are grouped into an UNKNOWN entry returned by the API.

@dsjen @rocha @mulby
