### PR TITLE
Redirecting Status sub-paths to Root

### DIFF
--- a/analytics_data_api/v0/tests/test_urls.py
+++ b/analytics_data_api/v0/tests/test_urls.py
@@ -1,0 +1,23 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+
+class UrlRedirectTests(TestCase):
+    api_root_path = '/api/v0/'
+
+    def assertRedirectsToRootPath(self, path, **kwargs):
+        assert_kwargs = {'status_code': 301}
+        assert_kwargs.update(kwargs)
+
+        p = '{0}{1}/'.format(self.api_root_path, path)
+        response = self.client.get(p)
+        self.assertRedirects(response, reverse(path), **assert_kwargs)
+
+    def test_authenticated(self):
+        self.assertRedirectsToRootPath('authenticated', target_status_code=401)
+
+    def test_health(self):
+        self.assertRedirectsToRootPath('health')
+
+    def test_status(self):
+        self.assertRedirectsToRootPath('status')

--- a/analytics_data_api/v0/urls/__init__.py
+++ b/analytics_data_api/v0/urls/__init__.py
@@ -1,7 +1,14 @@
 from django.conf.urls import patterns, url, include
+from django.core.urlresolvers import reverse_lazy
+from django.views.generic import RedirectView
 
 urlpatterns = patterns(
     '',
     url(r'^courses/', include('analytics_data_api.v0.urls.courses', namespace='courses')),
     url(r'^problems/', include('analytics_data_api.v0.urls.problems', namespace='problems')),
+
+    # pylint: disable=no-value-for-parameter
+    url(r'^authenticated/$', RedirectView.as_view(url=reverse_lazy('authenticated')), name='authenticated'),
+    url(r'^health/$', RedirectView.as_view(url=reverse_lazy('health')), name='health'),
+    url(r'^status/$', RedirectView.as_view(url=reverse_lazy('status')), name='status'),
 )

--- a/analyticsdataserver/urls.py
+++ b/analyticsdataserver/urls.py
@@ -15,9 +15,9 @@ urlpatterns = patterns(
     url(r'^api/', include('analytics_data_api.urls', namespace='api')),
     url(r'^docs/', include('rest_framework_swagger.urls')),
 
-    url(r'^status/$', views.StatusView.as_view()),
-    url(r'^authenticated/$', views.AuthenticationTestView.as_view()),
-    url(r'^health/$', views.HealthView.as_view()),
+    url(r'^status/$', views.StatusView.as_view(), name='status'),
+    url(r'^authenticated/$', views.AuthenticationTestView.as_view(), name='authenticated'),
+    url(r'^health/$', views.HealthView.as_view(), name='health'),
 )
 
 if settings.ENABLE_ADMIN_SITE:  # pragma: no cover


### PR DESCRIPTION
Calls to /api/v0/status|health|authenticated are now redirected to /status|health|authenticated.

@rocha @e0d 
