### PR TITLE
Remove deprecated setting; replace with new version.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -74,7 +74,7 @@ disable=
 output-format=text
 
 # Include message's id in output
-include-ids=yes
+msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be


### PR DESCRIPTION
@clintonb This should correct the problem. 

Pylint was returning a deprecation warning, but diff-quality was interpreting that as an error and raising an exception. What you see here is the update for the deprecate setting.
