### PR TITLE
Added missing forward slash to API endpoints

### DIFF
--- a/analytics_data_api/v0/tests/test_views.py
+++ b/analytics_data_api/v0/tests/test_views.py
@@ -392,7 +392,7 @@ class CourseEnrollmentByGenderViewTests(CourseEnrollmentViewTestCaseMixin, Defau
 
 # pylint: disable=no-member,no-value-for-parameter
 class AnswerDistributionTests(TestCaseWithAuthentication):
-    path = '/answer_distribution'
+    path = '/answer_distribution/'
     maxDiff = None
 
     @classmethod
@@ -630,7 +630,7 @@ class CourseActivityWeeklyViewTests(CourseViewTestCaseMixin, TestCaseWithAuthent
 
 # pylint: disable=no-member,no-value-for-parameter
 class GradeDistributionTests(TestCaseWithAuthentication):
-    path = '/grade_distribution'
+    path = '/grade_distribution/'
     maxDiff = None
 
     @classmethod
@@ -659,7 +659,7 @@ class GradeDistributionTests(TestCaseWithAuthentication):
 
 # pylint: disable=no-member,no-value-for-parameter
 class SequentialOpenDistributionTests(TestCaseWithAuthentication):
-    path = '/sequential_open_distribution'
+    path = '/sequential_open_distribution/'
     maxDiff = None
 
     @classmethod

--- a/analytics_data_api/v0/urls/problems.py
+++ b/analytics_data_api/v0/urls/problems.py
@@ -13,9 +13,9 @@ PROBLEM_URLS = [
 
 urlpatterns = patterns(
     '',
-    url(r'^(?P<module_id>.+)/sequential_open_distribution$',
+    url(r'^(?P<module_id>.+)/sequential_open_distribution/$',
         SequentialOpenDistributionView.as_view(), name='sequential_open_distribution'),
 )
 
 for path, view, name in PROBLEM_URLS:
-    urlpatterns += patterns('', url(r'^(?P<problem_id>.+)/' + re.escape(path) + r'$', view.as_view(), name=name))
+    urlpatterns += patterns('', url(r'^(?P<problem_id>.+)/' + re.escape(path) + r'/$', view.as_view(), name=name))


### PR DESCRIPTION
@dsjen pointed out to me this afternoon that these three API endpoints lack trailing forward slashes like the other ones.  This request brings them into compliance with the general standard for the other endpoints.  It is a fairly minor fix, but I'm planning to PR some methods for the client which hit these endpoints very soon, so it would be good to get it in.  Thanks! @jbau @clintonb 
