### PR TITLE
fix and expand fake data target used by analytics dashboard CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,9 @@ demo: requirements clean loaddata  ## Runs make clean, requirements, and loaddat
 github_ci: test.requirements clean migrate-all  ## Used by CI for testing
 	python manage.py set_api_key edx edx
 	python manage.py loaddata problem_response_answer_distribution --database=analytics
+	python manage.py loaddata problem_response_answer_distribution_analytics_v1 --database=analytics_v1
 	python manage.py generate_fake_course_data --database=analytics --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"
+	python manage.py generate_fake_course_data --database=analytics_v1 --num-weeks=2 --no-videos --course-id "edX/DemoX/Demo_Course"
 
 docker_build:
 	docker build . -f Dockerfile -t openedx/analytics-data-api

--- a/analytics_data_api/management/commands/generate_data.py
+++ b/analytics_data_api/management/commands/generate_data.py
@@ -333,11 +333,9 @@ def fake_video_ids_fallback():
     ]
 
 
-def generate_program_data(course_ids, program_title, database):
+def generate_program_data(course_ids, program_title, program_id, database):
     logger.info("Deleting existing course program data...")
     models.CourseProgramMetadata.objects.using(database).all().delete()
-
-    program_id = '01n3fb1531o8470b832209243z7y421a'
     program_type = 'Professional Certificate'
 
     for course_id in course_ids:

--- a/analytics_data_api/management/commands/generate_fake_course_data.py
+++ b/analytics_data_api/management/commands/generate_fake_course_data.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
 
         generate_weekly_data(course_id, start_date, end_date, database)
         generate_daily_data(course_id, start_date, end_date, database)
-        generate_program_data([course_id], 'Demo Program', database)
+        generate_program_data([course_id], 'Demo Program', 'Demo_Program', database)
         generate_all_video_data(course_id, video_ids, database)
         generate_learner_engagement_data(course_id, username, start_date, end_date, database)
         generate_learner_engagement_range_data(course_id, start_date.date(), end_date.date(), database)

--- a/analytics_data_api/management/commands/generate_stage_course_data.py
+++ b/analytics_data_api/management/commands/generate_stage_course_data.py
@@ -73,4 +73,4 @@ class Command(BaseCommand):
             generate_learner_engagement_range_data(course_id, start_date.date(), end_date.date(), database)
             generate_tags_distribution_data(course_id, database)
 
-        generate_program_data(PROGRAM_COURSE_IDS, program_title, database)
+        generate_program_data(PROGRAM_COURSE_IDS, program_title, '01n3fb1531o8470b832209243z7y421a', database)


### PR DESCRIPTION
The fake program ID is load bearing and we would also like there to be data in the V1 database for CI usage.