### PR TITLE
transform from a thousand queries to one

### DIFF
--- a/analytics_data_api/v0/tests/views/test_course_summaries.py
+++ b/analytics_data_api/v0/tests/views/test_course_summaries.py
@@ -225,17 +225,20 @@ class CourseSummariesViewTests(VerifyCourseIdMixin, TestCaseWithAuthentication, 
         expected_recent = recent_factor * len(enrollment_modes.ALL)
         recent_delta = expected_count - expected_recent
         self.generate_data(programs=True, recent_date=recent)
+
         expectedOnDate = self.all_expected_results(modes=enrollment_modes.ALL,
                                                    recent_count_change=recent_delta)
-
         responseOnDate = self.validated_request(exclude=self.always_exclude, recent_date=recent.strftime('%Y-%m-%d'))
         self.assertEqual(responseOnDate.status_code, 200)
         self.assertCountEqual(responseOnDate.data, expectedOnDate)
 
-        after = (recent + datetime.timedelta(1)).strftime('%Y-%m-%d')
-        responseAfterDate = self.validated_request(exclude=self.always_exclude, recent_date=after)
-        self.assertEqual(responseAfterDate.status_code, 200)
-        self.assertCountEqual(responseAfterDate.data, expectedOnDate)
+        expectedLimitedIDs = self.all_expected_results(modes=enrollment_modes.ALL, recent_count_change=recent_delta,
+                                                       ids=CourseSamples.course_ids[0:2])
+        responseLimitedIDs = self.validated_request(exclude=self.always_exclude,
+                                                    recent_date=recent.strftime('%Y-%m-%d'),
+                                                    ids=CourseSamples.course_ids[0:2])
+        self.assertEqual(responseLimitedIDs.status_code, 200)
+        self.assertCountEqual(responseLimitedIDs.data, expectedLimitedIDs)
 
         expectedBeforeDate = self.all_expected_results(modes=enrollment_modes.ALL, recent_count_change=expected_count)
         before = (recent - datetime.timedelta(1)).strftime('%Y-%m-%d')

--- a/analytics_data_api/v0/views/__init__.py
+++ b/analytics_data_api/v0/views/__init__.py
@@ -227,10 +227,6 @@ class APIListView(generics.ListAPIView):
         field_dict.update({field: getattr(model, field) for field in field_list})
         return field_dict
 
-    def postprocess_field_dict(self, field_dict):
-        """Applies some business logic to final result without access to any data from the original model."""
-        return field_dict
-
     def group_by_id(self, queryset):
         """Return results aggregated by a distinct ID."""
         aggregate_field_dict = []
@@ -240,7 +236,6 @@ class APIListView(generics.ListAPIView):
             for model in model_group:
                 field_dict = self.update_field_dict_from_model(model, base_field_dict=field_dict)
 
-            field_dict = self.postprocess_field_dict(field_dict)
             aggregate_field_dict.append(field_dict)
 
         return aggregate_field_dict


### PR DESCRIPTION
the previous version of CourseSummariesView worked like this:
First make query (via the super) using get_queryset.

get_queryset does an obvious single query and then does group_by_id.

group_by_id loops through all returns from the original query and
groups them by ID and in that loop calls a postprocessing method that
can do whatever you want.

In this case what we wanted to do was maybe call two different
functions (and some other stuff) EACH OF WHICH MAKES A DB CALL PER
ORIGINAL COURSE_ID. In the call we actually use only the add_recent
gets triggered.

I've pulled those queries out into a single query whose data is then
passed into the add_recent function. This also required doing a bit of
rejiggering of the hierarchy, CourseSummariesView now has its own
group_by_id and the parent group_by_id doesn't call postprocessing
because the only other user doesn't have it.

The only loss of functionality is that the original query would find
data for the given date per course or if that wasn't available any
earlier date. We call this only with 6 months and with the way we fill
the data if we don't have 6 months we aren't going to have any earlier
data either so there is no point making the query that complex. This
drops a clause from the tests which is no longer relevant. In exchange
I added one to make sure calls providing IDs worked with the new
method.

MST-1376