### PR TITLE
chore: remove django-countries constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.8
+boto3==1.21.9
     # via -r requirements/base.in
-botocore==1.24.8
+botocore==1.24.9
     # via
     #   boto3
     #   s3transfer
@@ -54,10 +54,8 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-countries==7.3.1
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -228,6 +226,8 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.63.0
     # via -r requirements/base.in
+typing-extensions==4.1.1
+    # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,6 +30,3 @@ tox==3.14.6
 # Use same version of edx-lint
 pylint==2.4.4
 pylint-django==2.0.11
-
-# django-countries 7.3 is incompatible with python 3.8
-django-countries<7.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.8
+boto3==1.21.9
     # via -r requirements/base.in
-botocore==1.24.8
+botocore==1.24.9
     # via
     #   boto3
     #   s3transfer
@@ -54,10 +54,8 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-countries==7.3.1
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -228,6 +226,8 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.63.0
     # via -r requirements/base.in
+typing-extensions==4.1.1
+    # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,9 +12,9 @@ babel==2.9.1
     # via sphinx
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.8
+boto3==1.21.9
     # via -r requirements/base.in
-botocore==1.24.8
+botocore==1.24.9
     # via
     #   boto3
     #   s3transfer
@@ -58,10 +58,8 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-countries==7.3.1
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -269,6 +267,8 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.63.0
     # via -r requirements/base.in
+typing-extensions==4.1.1
+    # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.8
+boto3==1.21.9
     # via -r requirements/base.in
-botocore==1.24.8
+botocore==1.24.9
     # via
     #   boto3
     #   s3transfer
@@ -54,10 +54,8 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-countries==7.3.1
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -242,6 +240,8 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.63.0
     # via -r requirements/base.in
+typing-extensions==4.1.1
+    # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,9 @@ attrs==21.4.0
     # via pytest
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.8
+boto3==1.21.9
     # via -r requirements/base.in
-botocore==1.24.8
+botocore==1.24.9
     # via
     #   boto3
     #   s3transfer
@@ -67,10 +67,8 @@ diff-cover==6.4.4
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-countries==7.3.1
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
@@ -294,6 +292,8 @@ tomli==2.0.1
     #   pytest
 tqdm==4.63.0
     # via -r requirements/base.in
+typing-extensions==4.1.1
+    # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1


### PR DESCRIPTION
A fix has been released for django-countries 7.3, so we can remove that constraint.