### PR TITLE
feat: upgrade requirements to catch enterprise data 4.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.9
+boto3==1.21.19
     # via -r requirements/base.in
-botocore==1.24.9
+botocore==1.24.19
     # via
     #   boto3
     #   s3transfer
@@ -54,7 +54,7 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.3.1
+django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -105,7 +105,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.0.0
+edx-enterprise-data==4.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -127,11 +127,15 @@ elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+factory-boy==3.2.1
+    # via edx-enterprise-data
+faker==13.3.2
+    # via factory-boy
 future==0.18.2
     # via pyjwkest
 idna==3.3
     # via requests
-importlib-metadata==4.11.2
+importlib-metadata==4.11.3
     # via markdown
 inflection==0.5.1
     # via drf-yasg
@@ -145,7 +149,7 @@ jmespath==0.10.0
     #   botocore
 markdown==3.3.6
     # via -r requirements/base.in
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 newrelic==7.6.0.173
     # via edx-django-utils
@@ -179,6 +183,7 @@ python-dateutil==2.8.2
     #   botocore
     #   edx-drf-extensions
     #   elasticsearch-dsl
+    #   faker
 python-memcached==1.59
     # via -r requirements/base.in
 pytz==2021.3
@@ -199,7 +204,7 @@ ruamel-yaml==0.17.21
     # via drf-yasg
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
-rules==3.1
+rules==3.2.1
     # via edx-enterprise-data
 s3transfer==0.5.2
     # via boto3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.9
+boto3==1.21.19
     # via -r requirements/base.in
-botocore==1.24.9
+botocore==1.24.19
     # via
     #   boto3
     #   s3transfer
@@ -54,7 +54,7 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.3.1
+django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -105,7 +105,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.0.0
+edx-enterprise-data==4.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -127,11 +127,15 @@ elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+factory-boy==3.2.1
+    # via edx-enterprise-data
+faker==13.3.2
+    # via factory-boy
 future==0.18.2
     # via pyjwkest
 idna==3.3
     # via requests
-importlib-metadata==4.11.2
+importlib-metadata==4.11.3
     # via markdown
 inflection==0.5.1
     # via drf-yasg
@@ -145,7 +149,7 @@ jmespath==0.10.0
     #   botocore
 markdown==3.3.6
     # via -r requirements/base.in
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 newrelic==7.6.0.173
     # via edx-django-utils
@@ -179,6 +183,7 @@ python-dateutil==2.8.2
     #   botocore
     #   edx-drf-extensions
     #   elasticsearch-dsl
+    #   faker
 python-memcached==1.59
     # via -r requirements/base.in
 pytz==2021.3
@@ -199,7 +204,7 @@ ruamel-yaml==0.17.21
     # via drf-yasg
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
-rules==3.1
+rules==3.2.1
     # via edx-enterprise-data
 s3transfer==0.5.2
     # via boto3

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,9 +12,9 @@ babel==2.9.1
     # via sphinx
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.9
+boto3==1.21.19
     # via -r requirements/base.in
-botocore==1.24.9
+botocore==1.24.19
     # via
     #   boto3
     #   s3transfer
@@ -58,7 +58,7 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.3.1
+django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -111,7 +111,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.0.0
+edx-enterprise-data==4.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -135,13 +135,17 @@ elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+factory-boy==3.2.1
+    # via edx-enterprise-data
+faker==13.3.2
+    # via factory-boy
 future==0.18.2
     # via pyjwkest
 idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.2
+importlib-metadata==4.11.3
     # via
     #   markdown
     #   sphinx
@@ -159,7 +163,7 @@ jmespath==0.10.0
     #   botocore
 markdown==3.3.6
     # via -r requirements/base.in
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 newrelic==7.6.0.173
     # via edx-django-utils
@@ -199,6 +203,7 @@ python-dateutil==2.8.2
     #   botocore
     #   edx-drf-extensions
     #   elasticsearch-dsl
+    #   faker
 python-memcached==1.59
     # via -r requirements/base.in
 pytz==2021.3
@@ -221,7 +226,7 @@ ruamel-yaml==0.17.21
     # via drf-yasg
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
-rules==3.1
+rules==3.2.1
     # via edx-enterprise-data
 s3transfer==0.5.2
     # via boto3

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.3
+pip==22.0.4
     # via -r requirements/pip.in
 setuptools==60.9.3
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.9
+boto3==1.21.19
     # via -r requirements/base.in
-botocore==1.24.9
+botocore==1.24.19
     # via
     #   boto3
     #   s3transfer
@@ -54,7 +54,7 @@ django==3.2.12
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.3.1
+django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -105,7 +105,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.0.0
+edx-enterprise-data==4.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -127,6 +127,10 @@ elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+factory-boy==3.2.1
+    # via edx-enterprise-data
+faker==13.3.2
+    # via factory-boy
 future==0.18.2
     # via pyjwkest
 gevent==21.12.0
@@ -137,7 +141,7 @@ gunicorn==20.1.0
     # via -r requirements/production.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.2
+importlib-metadata==4.11.3
     # via markdown
 inflection==0.5.1
     # via drf-yasg
@@ -151,7 +155,7 @@ jmespath==0.10.0
     #   botocore
 markdown==3.3.6
     # via -r requirements/base.in
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 mysqlclient==2.1.0
     # via -r requirements/production.in
@@ -191,6 +195,7 @@ python-dateutil==2.8.2
     #   botocore
     #   edx-drf-extensions
     #   elasticsearch-dsl
+    #   faker
 python-memcached==1.59
     # via -r requirements/base.in
 pytz==2021.3
@@ -213,7 +218,7 @@ ruamel-yaml==0.17.21
     # via drf-yasg
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
-rules==3.1
+rules==3.2.1
     # via edx-enterprise-data
 s3transfer==0.5.2
     # via boto3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,9 @@ attrs==21.4.0
     # via pytest
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.9
+boto3==1.21.19
     # via -r requirements/base.in
-botocore==1.24.9
+botocore==1.24.19
     # via
     #   boto3
     #   s3transfer
@@ -67,7 +67,7 @@ diff-cover==6.4.4
     #   edx-rbac
 django-cors-headers==3.11.0
     # via -r requirements/base.in
-django-countries==7.3.1
+django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -120,7 +120,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.0.0
+edx-enterprise-data==4.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -142,13 +142,17 @@ elasticsearch-dsl==7.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-freezegun==1.1.0
+factory-boy==3.2.1
+    # via edx-enterprise-data
+faker==13.3.2
+    # via factory-boy
+freezegun==1.2.0
     # via -r requirements/test.in
 future==0.18.2
     # via pyjwkest
 idna==3.3
     # via requests
-importlib-metadata==4.11.2
+importlib-metadata==4.11.3
     # via markdown
 inflection==0.5.1
     # via drf-yasg
@@ -170,7 +174,7 @@ lazy-object-proxy==1.4.3
     # via astroid
 markdown==3.3.6
     # via -r requirements/base.in
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via pylint
@@ -219,7 +223,7 @@ pymongo==3.12.3
     # via edx-opaque-keys
 pyparsing==3.0.7
     # via packaging
-pytest==7.0.1
+pytest==7.1.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -232,6 +236,7 @@ python-dateutil==2.8.2
     #   botocore
     #   edx-drf-extensions
     #   elasticsearch-dsl
+    #   faker
     #   freezegun
 python-memcached==1.59
     # via -r requirements/base.in
@@ -251,13 +256,13 @@ requests==2.27.1
     #   pyjwkest
     #   responses
     #   slumber
-responses==0.18.0
+responses==0.19.0
     # via -r requirements/test.in
 ruamel-yaml==0.17.21
     # via drf-yasg
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
-rules==3.1
+rules==3.2.1
     # via edx-enterprise-data
 s3transfer==0.5.2
     # via boto3

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -33,5 +33,5 @@ tox==3.14.6
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/tox.in
-virtualenv==20.13.2
+virtualenv==20.13.3
     # via tox


### PR DESCRIPTION
there's only one requirement we need today, but it's an excuse to generally upgrade