### PR TITLE
chore: upgrade enterprise-data version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -105,7 +105,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.2.1
+edx-enterprise-data==4.2.3
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -239,7 +239,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.in
     #   botocore

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -16,5 +16,5 @@ idna==3.3
     # via requests
 requests==2.27.1
     # via codecov
-urllib3==1.26.8
+urllib3==1.26.9
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -105,7 +105,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.2.1
+edx-enterprise-data==4.2.3
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -239,7 +239,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.in
     #   botocore

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -111,7 +111,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.2.1
+edx-enterprise-data==4.2.3
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -280,7 +280,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.in
     #   botocore

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.37.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.0.4
     # via -r requirements/pip.in
-setuptools==60.9.3
+setuptools==60.10.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -105,7 +105,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.2.1
+edx-enterprise-data==4.2.3
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -253,7 +253,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.in
     #   botocore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -120,7 +120,7 @@ edx-drf-extensions==8.0.1
     #   -r requirements/base.in
     #   edx-enterprise-data
     #   edx-rbac
-edx-enterprise-data==4.2.1
+edx-enterprise-data==4.2.3
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -305,7 +305,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.in
     #   botocore


### PR DESCRIPTION
Update enterprise data to the latest version, which contains a fix to handle rate limiting when making calls to the LMS to retrieve enterprise customer details.