### PR TITLE
feat: format answer distribution fields

### DIFF
--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -121,7 +121,8 @@ class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedFiel
             text = self._get_text_from_html(value)
             return self._parse_slugged_slashes(text)
 
-        # attempt to evaluate string as a list, else keep it a string
+        # attempt to evaluate string as a list (this will get special
+        # formatting), else keep it a string
         try:
             answer_eval = json.loads(answer_value.encode('unicode_escape'))
             if isinstance(answer_eval, list):
@@ -183,7 +184,7 @@ class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedFiel
         we need to remove the slugs so that it is consumable/readable in insights.
         """
         # order matters if a we have a key that is a substring of another key
-        # this is not the case right now but let's use in ordered dict anyway
+        # this is not the case right now but use an ordered dict so results are deterministic
         replacements = OrderedDict({
             '**FOURBACKSLASHQUOTE**': '\\\\\\\\"',
             '**THREEBACKSLASHQUOTE**': '\\\\\\"',

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -159,7 +159,7 @@ class ProblemResponseAnswerDistributionSerializer(ModelSerializerWithCreatedFiel
                 text_list.extend(val.strip().split(' '))
             text = u' '.join(text_list)
         except Exception:  # pylint: disable=broad-except
-            text = markup.strip()
+            text = ''
 
         return text
 

--- a/analytics_data_api/v0/tests/test_serializers.py
+++ b/analytics_data_api/v0/tests/test_serializers.py
@@ -41,7 +41,7 @@ class ProblemResponseAnswerDistributionSerializerTests(TestCase):
         ('justastring', 'justastring'),
         ('25.94', '25.94'),
         ('[0, 100, 7, "x", "Duōshǎo"]', '[0|100|7|x|Duōshǎo]'),
-        ('"a","b" <choicehint>Correct.</choicehint>', '"a","b" Correct.'),
+        ('"a","b" <choicehint>Correct.</choicehint> o', '"a","b" Correct. o'),
         ('[{"3":"t1"},{"2":"t2"}]', '[{"3": "t1"}|{"2": "t2"}]'),
         ('[[1,0,0],[0,1,0],[0,0,1],[0,0,0]]', '[[1, 0, 0]|[0, 1, 0]|[0, 0, 1]|[0, 0, 0]]'),
         ('["<text>(S \\to D \\to G)</text>"]', '[(S \\to D \\to G)]'),

--- a/analytics_data_api/v0/tests/test_serializers.py
+++ b/analytics_data_api/v0/tests/test_serializers.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+import ddt
 from django.test import TestCase
 from django_dynamic_fixture import G
 
@@ -29,3 +30,47 @@ class DynamicFieldsModelSerializerTests(TestCase):
         instance = G(api_models.CourseEnrollmentDaily, course_id='3', count=1, date=now)
         serialized = TestSerializer(instance, exclude=('course_id',))
         self.assertListEqual(list(serialized.data.keys()), ['date', 'count', 'created'])
+
+
+@set_databases
+@ddt.ddt
+class ProblemResponseAnswerDistributionSerializerTests(TestCase):
+
+    @ddt.data(
+        ('', ''),
+        ('justastring', 'justastring'),
+        ('25.94', '25.94'),
+        ('[0, 100, 7, "x", "Duōshǎo"]', '[0|100|7|x|Duōshǎo]'),
+        ('"a","b" <choicehint>Correct.</choicehint>', '"a","b" Correct.'),
+        ('[{"3":"t1"},{"2":"t2"}]', '[{"3": "t1"}|{"2": "t2"}]'),
+        ('[[1,0,0],[0,1,0],[0,0,1],[0,0,0]]', '[[1, 0, 0]|[0, 1, 0]|[0, 0, 1]|[0, 0, 0]]'),
+        ('["<text>(S \\to D \\to G)</text>"]', '[(S \\to D \\to G)]'),
+        ('\\((2,1,3)^\\n\\)', '\\((2,1,3)^\\n\\)'),
+        (
+            'MLE [mathjax]\\widehat{\\theta }_ n^{\\text {MLE}}[/mathjax]',
+            'MLE [mathjax]\\widehat{\\theta }_ n^{\\text {MLE}}[/mathjax]'
+        ),
+        ('<img src="doggo.png" height="100"/>', ''),
+        ('<table><tr><td>(0</td><td>1/3</td><td>0)</td></tr></table>', '(0 1/3 0)'),
+    )
+    @ddt.unpack
+    def test_answer_formatting(self, answer_value, expected_display):
+        instance = G(
+            api_models.ProblemFirstLastResponseAnswerDistribution,
+            answer_value=answer_value,
+            value_id=answer_value
+        )
+        serialized = api_serializers.ProblemFirstLastResponseAnswerDistributionSerializer(instance)
+        self.assertEqual(serialized.data['answer_value'], expected_display)
+        self.assertEqual(serialized.data['value_id'], expected_display)
+
+    @ddt.data(
+        ('"hello**ONEBACKSLASHQUOTE**', '"hello\\"'),
+        ('**BACKSLASHSPACE**hello', '\\ hello'),
+        ('**FOURBACKSLASHQUOTE****TWOBACKSLASHQUOTE**', '\\\\\\\\"\\\\"'),
+    )
+    @ddt.unpack
+    def test_answer_value_unslugged(self, answer_value, expected_display):
+        instance = G(api_models.ProblemFirstLastResponseAnswerDistribution, answer_value=answer_value)
+        serialized = api_serializers.ProblemFirstLastResponseAnswerDistributionSerializer(instance)
+        self.assertEqual(serialized.data['answer_value'], expected_display)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,6 +13,7 @@ djangorestframework                 # BSD
 djangorestframework-csv             # BSD
 django-storages                     # BSD
 elasticsearch-dsl                   # Apache 2.0
+html5lib			    # MIT
 ordered-set                         # MIT
 tqdm                                # MIT
 urllib3                             # MIT

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.40
+boto3==1.21.44
     # via -r requirements/base.in
-botocore==1.24.40
+botocore==1.24.44
     # via
     #   boto3
     #   s3transfer
@@ -129,10 +129,12 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.3.4
+faker==13.3.5
     # via factory-boy
 future==0.18.2
     # via pyjwkest
+html5lib==1.1
+    # via -r requirements/base.in
 idna==3.3
     # via requests
 importlib-metadata==4.11.3
@@ -218,6 +220,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-rbac
     #   elasticsearch-dsl
+    #   html5lib
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -231,7 +234,7 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.64.0
     # via -r requirements/base.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
@@ -245,5 +248,7 @@ urllib3==1.26.9
     #   botocore
     #   elasticsearch
     #   requests
+webencodings==0.5.1
+    # via html5lib
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.40
+boto3==1.21.44
     # via -r requirements/base.in
-botocore==1.24.40
+botocore==1.24.44
     # via
     #   boto3
     #   s3transfer
@@ -129,10 +129,12 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.3.4
+faker==13.3.5
     # via factory-boy
 future==0.18.2
     # via pyjwkest
+html5lib==1.1
+    # via -r requirements/base.in
 idna==3.3
     # via requests
 importlib-metadata==4.11.3
@@ -218,6 +220,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-rbac
     #   elasticsearch-dsl
+    #   html5lib
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -231,7 +234,7 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.64.0
     # via -r requirements/base.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
@@ -245,5 +248,7 @@ urllib3==1.26.9
     #   botocore
     #   elasticsearch
     #   requests
+webencodings==0.5.1
+    # via html5lib
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,13 +8,13 @@ alabaster==0.7.12
     # via sphinx
 asgiref==3.5.0
     # via django
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.40
+boto3==1.21.44
     # via -r requirements/base.in
-botocore==1.24.40
+botocore==1.24.44
     # via
     #   boto3
     #   s3transfer
@@ -137,10 +137,12 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.3.4
+faker==13.3.5
     # via factory-boy
 future==0.18.2
     # via pyjwkest
+html5lib==1.1
+    # via -r requirements/base.in
 idna==3.3
     # via requests
 imagesize==1.3.0
@@ -241,6 +243,7 @@ six==1.16.0
     #   edx-rbac
     #   edx-sphinx-theme
     #   elasticsearch-dsl
+    #   html5lib
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -272,7 +275,7 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.64.0
     # via -r requirements/base.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
@@ -286,5 +289,7 @@ urllib3==1.26.9
     #   botocore
     #   elasticsearch
     #   requests
+webencodings==0.5.1
+    # via html5lib
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,9 +8,9 @@ asgiref==3.5.0
     # via django
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.40
+boto3==1.21.44
     # via -r requirements/base.in
-botocore==1.24.40
+botocore==1.24.44
     # via
     #   boto3
     #   s3transfer
@@ -129,7 +129,7 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.3.4
+faker==13.3.5
     # via factory-boy
 future==0.18.2
     # via pyjwkest
@@ -139,6 +139,8 @@ greenlet==1.1.2
     # via gevent
 gunicorn==20.1.0
     # via -r requirements/production.in
+html5lib==1.1
+    # via -r requirements/base.in
 idna==3.3
     # via requests
 importlib-metadata==4.11.3
@@ -232,6 +234,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-rbac
     #   elasticsearch-dsl
+    #   html5lib
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -245,7 +248,7 @@ stevedore==3.5.0
     #   edx-opaque-keys
 tqdm==4.64.0
     # via -r requirements/base.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
@@ -259,6 +262,8 @@ urllib3==1.26.9
     #   botocore
     #   elasticsearch
     #   requests
+webencodings==0.5.1
+    # via html5lib
 zipp==3.8.0
     # via importlib-metadata
 zope-event==4.5.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,9 @@ attrs==21.4.0
     # via pytest
 boto==2.42.0
     # via -r requirements/base.in
-boto3==1.21.40
+boto3==1.21.44
     # via -r requirements/base.in
-botocore==1.24.40
+botocore==1.24.44
     # via
     #   boto3
     #   s3transfer
@@ -46,7 +46,7 @@ cryptography==36.0.2
     #   pyjwt
 ddt==1.4.4
     # via -r requirements/test.in
-diff-cover==6.4.5
+diff-cover==6.5.0
     # via -r requirements/test.in
     # via
     #   -c requirements/constraints.txt
@@ -144,12 +144,14 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.3.4
+faker==13.3.5
     # via factory-boy
 freezegun==1.2.1
     # via -r requirements/test.in
 future==0.18.2
     # via pyjwkest
+html5lib==1.1
+    # via -r requirements/base.in
 idna==3.3
     # via requests
 importlib-metadata==4.11.3
@@ -278,6 +280,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-rbac
     #   elasticsearch-dsl
+    #   html5lib
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -297,7 +300,7 @@ tomli==2.0.1
     #   pytest
 tqdm==4.64.0
     # via -r requirements/base.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
@@ -312,6 +315,8 @@ urllib3==1.26.9
     #   elasticsearch
     #   requests
     #   responses
+webencodings==0.5.1
+    # via html5lib
 wrapt==1.11.2
     # via astroid
 zipp==3.8.0

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,7 +12,7 @@ filelock==3.6.0
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==0.13.1
     # via tox


### PR DESCRIPTION
Answer values in the old data pipeline went through formatting so they could be presentable in the insights UI. The new pipeline has no such formatting so these values need to be cleaned after being fetched from the database.

Also we need to do some additional processing to undo replacements made due two problematic escape sequences in snowflake.

https://openedx.atlassian.net/browse/MST-1454