### PR TITLE
feat: add default throttling to analytics-data-api

### DIFF
--- a/analytics_data_api/tests/test_throttles.py
+++ b/analytics_data_api/tests/test_throttles.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+
+from django.core.cache import caches
+from django.test import override_settings
+
+from analytics_data_api.throttles import ServiceUserThrottle
+from analyticsdataserver.tests.utils import TestCaseWithAuthentication
+
+
+class RateLimitingTests(TestCaseWithAuthentication):
+    """
+    Test cases for the rate limiting of analytics API calls
+    """
+
+    worker_name = 'test_worker'
+
+    def setUp(self):
+        super().setUp()
+        self.path = '/docs'
+
+    def tearDown(self):
+        super().tearDown()
+        caches['default'].clear()
+
+    def _make_requests(self, num_requests, throttle_rate):
+        """
+        Make num_requests to an endpoint
+        Return the response from the last request
+        """
+        with patch('rest_framework.views.APIView.throttle_classes', (ServiceUserThrottle,)):
+            with patch.object(ServiceUserThrottle, 'THROTTLE_RATES', throttle_rate):
+                for __ in range(num_requests - 1):
+                    response = self.authenticated_get(self.path)
+                    assert response.status_code == 200
+                response = self.authenticated_get(self.path)
+        return response
+
+    def test_rate_limiting(self):
+        response = self._make_requests(6, {'user': '5/hour'})
+        assert response.status_code == 429
+
+    @override_settings(
+        ANALYTICS_API_SERVICE_USERNAMES=[worker_name],
+    )
+    def test_allowed_service_user(self):
+        self.test_user.username = self.worker_name
+        self.test_user.save()
+
+        response = self._make_requests(5, {'service_user': '10/hour', 'user': '1/hour'})
+        assert response.status_code == 200
+
+    @override_settings(
+        ANALYTICS_API_SERVICE_USERNAMES=[worker_name],
+    )
+    def test_denied_service_user(self):
+        self.test_user.username = self.worker_name
+        self.test_user.save()
+
+        response = self._make_requests(6, {'service_user': '5/hour', 'user': '1/hour'})
+        assert response.status_code == 429

--- a/analytics_data_api/throttles.py
+++ b/analytics_data_api/throttles.py
@@ -1,0 +1,45 @@
+"""
+Throttle classes for edx-analytics-data-api.
+"""
+from django.conf import settings
+from rest_framework.throttling import UserRateThrottle
+
+SERVICE_USER_SCOPE = 'service_user'
+
+
+class ServiceUserThrottle(UserRateThrottle):
+    """
+    A throttle allowing the service user to override rate limiting.
+    """
+
+    def allow_request(self, request, view):
+        """
+        Modify throttling for service users.
+        Updates throttling rate if the request is coming from the service user, and
+        defaults to UserRateThrottle's configured setting otherwise.
+        Updated throttling rate comes from `DEFAULT_THROTTLE_RATES` key in `REST_FRAMEWORK`
+        setting. service user throttling is specified in `DEFAULT_THROTTLE_RATES` by `service_user` key
+        Example Setting::
+            REST_FRAMEWORK = {
+                ...
+                'DEFAULT_THROTTLE_RATES': {
+                    ...
+                    'service_user': '50/day'
+                }
+            }
+        """
+        service_users = getattr(settings, 'ANALYTICS_API_SERVICE_USERNAMES', None)
+
+        # User service user throttling rates for service user.
+        if service_users and request.user.username in service_users:
+            self.update_throttle_scope()
+
+        return super().allow_request(request, view)
+
+    def update_throttle_scope(self):
+        """
+        Update throttle scope so that service user throttle rates are applied.
+        """
+        self.scope = SERVICE_USER_SCOPE
+        self.rate = self.get_rate()
+        self.num_requests, self.duration = self.parse_rate(self.rate)

--- a/analyticsdataserver/settings/base.py
+++ b/analyticsdataserver/settings/base.py
@@ -373,7 +373,16 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
         'analytics_data_api.renderers.PaginatedCsvRenderer',
-    )
+    ),
+
+    'DEFAULT_THROTTLE_CLASSES': (
+        'analytics_data_api.throttles.ServiceUserThrottle',
+    ),
+
+    'DEFAULT_THROTTLE_RATES': {
+        'user': '60/minute',
+        'service_user': '800/minute',
+    },
 }
 ########## END REST FRAMEWORK CONFIGURATION
 
@@ -390,6 +399,13 @@ LMS_BASE_URL = None
 
 # base url to generate link to user api
 LMS_USER_ACCOUNT_BASE_URL = None
+
+# Defines the usernames of service users who should be throttled
+# at a higher rate than normal users.
+ANALYTICS_API_SERVICE_USERNAMES = [
+    'enterprise_worker',
+    'ecommerce_worker',
+]
 
 # settings for report downloads
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'

--- a/analyticsdataserver/settings/test.py
+++ b/analyticsdataserver/settings/test.py
@@ -59,3 +59,6 @@ FTP_STORAGE_LOCATION = 'ftp://localhost:80/path'
 # Default settings for report download endpoint
 COURSE_REPORT_FILE_LOCATION_TEMPLATE = '/{course_id}_{report_name}.csv'
 COURSE_REPORT_DOWNLOAD_EXPIRY_TIME = 120
+
+# Disable throttling during most testing, as it just adds queries
+REST_FRAMEWORK['DEFAULT_THROTTLE_CLASSES'] = ()

--- a/analyticsdataserver/tests/utils.py
+++ b/analyticsdataserver/tests/utils.py
@@ -6,8 +6,8 @@ from rest_framework.authtoken.models import Token
 class TestCaseWithAuthentication(TestCase):
     def setUp(self):
         super().setUp()
-        test_user = User.objects.create_user('tester', 'test@example.com', 'testpassword')
-        self.token = Token.objects.create(user=test_user)
+        self.test_user = User.objects.create_user('tester', 'test@example.com', 'testpassword')
+        self.token = Token.objects.create(user=self.test_user)
 
     def authenticated_get(self, path, data=None, follow=True, **extra):
         data = data or {}


### PR DESCRIPTION
We currently don't have any rate limiting in place for the analytics-data-api. This PR defines default throttling rates for users and services, and uses a custom throttling class to account for service users. 

Service users can be updated via the `ANALYTICS_API_SERVICE_USERNAMES` setting.

This type of throttling is similar to what's done in course-discovery.