### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ upgrade:
 	pip3 install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3422