### PR TITLE
chore: upgrade requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,24 +4,28 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.22.0
+boto3==1.24.18
     # via -r requirements/base.in
-botocore==1.25.0
+botocore==1.27.18
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   elasticsearch
     #   requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   cryptography
+    #   pynacl
 charset-normalizer==2.0.12
     # via requests
+click==8.1.3
+    # via edx-django-utils
 coreapi==2.3.3
     # via
     #   -r requirements/base.in
@@ -30,7 +34,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==37.0.0
+cryptography==37.0.2
     # via
     #   django-fernet-fields
     #   pyjwt
@@ -41,6 +45,7 @@ django==3.2.13
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields
+    #   django-filter
     #   django-model-utils
     #   django-storages
     #   djangorestframework
@@ -52,7 +57,7 @@ django==3.2.13
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==3.11.0
+django-cors-headers==3.13.0
     # via -r requirements/base.in
 django-countries==7.3.2
     # via -r requirements/base.in
@@ -62,6 +67,8 @@ django-crum==0.7.9
     #   edx-rbac
 django-fernet-fields==0.6
     # via edx-enterprise-data
+django-filter==22.1
+    # via edx-enterprise-data
 django-model-utils==4.2.0
     # via
     #   edx-enterprise-data
@@ -70,7 +77,7 @@ django-storages==1.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-waffle==2.4.1
+django-waffle==2.5.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
@@ -94,7 +101,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.6.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -129,7 +136,7 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.4.0
+faker==13.14.0
     # via factory-boy
 future==0.18.2
     # via pyjwkest
@@ -137,46 +144,48 @@ html5lib==1.1
     # via -r requirements/base.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via markdown
 inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via coreschema
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markdown==3.3.6
+markdown==3.3.7
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
-newrelic==7.10.0.175
+newrelic==7.12.0.176
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in
 packaging==21.3
     # via drf-yasg
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymongo==3.12.3
     # via edx-opaque-keys
-pyparsing==3.0.8
+pynacl==1.5.0
+    # via edx-django-utils
+pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
     # via
@@ -192,7 +201,7 @@ pytz==2022.1
     #   djangorestframework
 pyyaml==6.0
     # via edx-django-release-util
-requests==2.27.1
+requests==2.28.0
     # via
     #   coreapi
     #   edx-drf-extensions
@@ -206,9 +215,9 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 rules==3.3
     # via edx-enterprise-data
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.16.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
 charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3.2
+coverage==6.4.1
     # via codecov
 idna==3.3
     # via requests
-requests==2.27.1
+requests==2.28.0
     # via codecov
 urllib3==1.26.9
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,24 +4,28 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.22.0
+boto3==1.24.18
     # via -r requirements/base.in
-botocore==1.25.0
+botocore==1.27.18
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   elasticsearch
     #   requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   cryptography
+    #   pynacl
 charset-normalizer==2.0.12
     # via requests
+click==8.1.3
+    # via edx-django-utils
 coreapi==2.3.3
     # via
     #   -r requirements/base.in
@@ -30,7 +34,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==37.0.0
+cryptography==37.0.2
     # via
     #   django-fernet-fields
     #   pyjwt
@@ -41,6 +45,7 @@ django==3.2.13
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields
+    #   django-filter
     #   django-model-utils
     #   django-storages
     #   djangorestframework
@@ -52,7 +57,7 @@ django==3.2.13
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==3.11.0
+django-cors-headers==3.13.0
     # via -r requirements/base.in
 django-countries==7.3.2
     # via -r requirements/base.in
@@ -62,6 +67,8 @@ django-crum==0.7.9
     #   edx-rbac
 django-fernet-fields==0.6
     # via edx-enterprise-data
+django-filter==22.1
+    # via edx-enterprise-data
 django-model-utils==4.2.0
     # via
     #   edx-enterprise-data
@@ -70,7 +77,7 @@ django-storages==1.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-waffle==2.4.1
+django-waffle==2.5.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
@@ -94,7 +101,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.6.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -129,7 +136,7 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.4.0
+faker==13.14.0
     # via factory-boy
 future==0.18.2
     # via pyjwkest
@@ -137,46 +144,48 @@ html5lib==1.1
     # via -r requirements/base.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via markdown
 inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via coreschema
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markdown==3.3.6
+markdown==3.3.7
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
-newrelic==7.10.0.175
+newrelic==7.12.0.176
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in
 packaging==21.3
     # via drf-yasg
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymongo==3.12.3
     # via edx-opaque-keys
-pyparsing==3.0.8
+pynacl==1.5.0
+    # via edx-django-utils
+pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
     # via
@@ -192,7 +201,7 @@ pytz==2022.1
     #   djangorestframework
 pyyaml==6.0
     # via edx-django-release-util
-requests==2.27.1
+requests==2.28.0
     # via
     #   coreapi
     #   edx-drf-extensions
@@ -206,9 +215,9 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 rules==3.3
     # via edx-enterprise-data
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.16.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,26 +6,30 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
-babel==2.10.1
+babel==2.10.3
     # via sphinx
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.22.0
+boto3==1.24.18
     # via -r requirements/base.in
-botocore==1.25.0
+botocore==1.27.18
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   elasticsearch
     #   requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   cryptography
+    #   pynacl
 charset-normalizer==2.0.12
     # via requests
+click==8.1.3
+    # via edx-django-utils
 coreapi==2.3.3
     # via
     #   -r requirements/base.in
@@ -34,7 +38,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==37.0.0
+cryptography==37.0.2
     # via
     #   django-fernet-fields
     #   pyjwt
@@ -45,6 +49,7 @@ django==3.2.13
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields
+    #   django-filter
     #   django-model-utils
     #   django-storages
     #   djangorestframework
@@ -56,7 +61,7 @@ django==3.2.13
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==3.11.0
+django-cors-headers==3.13.0
     # via -r requirements/base.in
 django-countries==7.3.2
     # via -r requirements/base.in
@@ -66,6 +71,8 @@ django-crum==0.7.9
     #   edx-rbac
 django-fernet-fields==0.6
     # via edx-enterprise-data
+django-filter==22.1
+    # via edx-enterprise-data
 django-model-utils==4.2.0
     # via
     #   edx-enterprise-data
@@ -74,7 +81,7 @@ django-storages==1.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-waffle==2.4.1
+django-waffle==2.5.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
@@ -88,7 +95,7 @@ djangorestframework==3.13.1
     #   edx-drf-extensions
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-docutils==0.17.1
+docutils==0.18.1
     # via sphinx
 drf-jwt==1.19.2
     # via edx-drf-extensions
@@ -100,7 +107,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.6.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -137,7 +144,7 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.4.0
+faker==13.14.0
     # via factory-boy
 future==0.18.2
     # via pyjwkest
@@ -147,7 +154,7 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via
     #   markdown
     #   sphinx
@@ -155,19 +162,19 @@ inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   coreschema
     #   sphinx
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markdown==3.3.6
+markdown==3.3.7
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
-newrelic==7.10.0.175
+newrelic==7.12.0.176
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in
@@ -177,26 +184,28 @@ packaging==21.3
     #   sphinx
 path==16.4.0
     # via -r requirements/doc.in
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pygments==2.12.0
     # via sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymongo==3.12.3
     # via edx-opaque-keys
-pyparsing==3.0.8
+pynacl==1.5.0
+    # via edx-django-utils
+pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
     # via
@@ -213,7 +222,7 @@ pytz==2022.1
     #   djangorestframework
 pyyaml==6.0
     # via edx-django-release-util
-requests==2.27.1
+requests==2.28.0
     # via
     #   coreapi
     #   edx-drf-extensions
@@ -228,9 +237,9 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 rules==3.3
     # via edx-enterprise-data
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.16.0
     # via
@@ -249,7 +258,7 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
+sphinx==5.0.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.4
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==62.1.0
+setuptools==62.6.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,16 +4,24 @@
 #
 #    make upgrade
 #
-click==8.1.2
+build==0.8.0
     # via pip-tools
+click==8.1.3
+    # via pip-tools
+packaging==21.3
+    # via build
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.0
+    # via build
+pip-tools==6.7.0
     # via -r requirements/pip_tools.in
+pyparsing==3.0.9
+    # via packaging
 six==1.16.0
     # via -r requirements/pip_tools.in
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,24 +4,28 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.22.0
+boto3==1.24.18
     # via -r requirements/base.in
-botocore==1.25.0
+botocore==1.27.18
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   elasticsearch
     #   requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   cryptography
+    #   pynacl
 charset-normalizer==2.0.12
     # via requests
+click==8.1.3
+    # via edx-django-utils
 coreapi==2.3.3
     # via
     #   -r requirements/base.in
@@ -30,7 +34,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==37.0.0
+cryptography==37.0.2
     # via
     #   django-fernet-fields
     #   pyjwt
@@ -41,6 +45,7 @@ django==3.2.13
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields
+    #   django-filter
     #   django-model-utils
     #   django-storages
     #   djangorestframework
@@ -52,7 +57,7 @@ django==3.2.13
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==3.11.0
+django-cors-headers==3.13.0
     # via -r requirements/base.in
 django-countries==7.3.2
     # via -r requirements/base.in
@@ -62,6 +67,8 @@ django-crum==0.7.9
     #   edx-rbac
 django-fernet-fields==0.6
     # via edx-enterprise-data
+django-filter==22.1
+    # via edx-enterprise-data
 django-model-utils==4.2.0
     # via
     #   edx-enterprise-data
@@ -70,7 +77,7 @@ django-storages==1.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-waffle==2.4.1
+django-waffle==2.5.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
@@ -94,7 +101,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.6.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -129,7 +136,7 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.4.0
+faker==13.14.0
     # via factory-boy
 future==0.18.2
     # via pyjwkest
@@ -143,25 +150,25 @@ html5lib==1.1
     # via -r requirements/base.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via markdown
 inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via coreschema
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markdown==3.3.6
+markdown==3.3.7
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/production.in
-newrelic==7.10.0.175
+newrelic==7.12.0.176
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -171,24 +178,26 @@ packaging==21.3
     # via drf-yasg
 path-py==8.2.1
     # via -r requirements/production.in
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
 pymongo==3.12.3
     # via edx-opaque-keys
-pyparsing==3.0.8
+pynacl==1.5.0
+    # via edx-django-utils
+pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
     # via
@@ -206,7 +215,7 @@ pyyaml==6.0
     # via
     #   -r requirements/production.in
     #   edx-django-release-util
-requests==2.27.1
+requests==2.28.0
     # via
     #   coreapi
     #   edx-drf-extensions
@@ -220,9 +229,9 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 rules==3.3
     # via edx-enterprise-data
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.16.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 astroid==2.3.3
     # via pylint
@@ -12,22 +12,26 @@ attrs==21.4.0
     # via pytest
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.22.0
+boto3==1.24.18
     # via -r requirements/base.in
-botocore==1.25.0
+botocore==1.27.18
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   elasticsearch
     #   requests
 cffi==1.15.0
-    # via cryptography
-chardet==4.0.0
+    # via
+    #   cryptography
+    #   pynacl
+chardet==5.0.0
     # via diff-cover
 charset-normalizer==2.0.12
     # via requests
+click==8.1.3
+    # via edx-django-utils
 coreapi==2.3.3
     # via
     #   -r requirements/base.in
@@ -36,17 +40,17 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.3.2
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==37.0.0
+cryptography==37.0.2
     # via
     #   django-fernet-fields
     #   pyjwt
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.in
-diff-cover==6.5.0
+diff-cover==6.5.1
     # via -r requirements/test.in
     # via
     #   -c requirements/constraints.txt
@@ -54,6 +58,7 @@ diff-cover==6.5.0
     #   django-cors-headers
     #   django-crum
     #   django-fernet-fields
+    #   django-filter
     #   django-model-utils
     #   django-storages
     #   djangorestframework
@@ -65,7 +70,7 @@ diff-cover==6.5.0
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rbac
-django-cors-headers==3.11.0
+django-cors-headers==3.13.0
     # via -r requirements/base.in
 django-countries==7.3.2
     # via -r requirements/base.in
@@ -77,6 +82,8 @@ django-dynamic-fixture==3.1.2
     # via -r requirements/test.in
 django-fernet-fields==0.6
     # via edx-enterprise-data
+django-filter==22.1
+    # via edx-enterprise-data
 django-model-utils==4.2.0
     # via
     #   edx-enterprise-data
@@ -85,7 +92,7 @@ django-storages==1.8
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-waffle==2.4.1
+django-waffle==2.5.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
@@ -109,7 +116,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.6.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -144,7 +151,7 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
 factory-boy==3.2.1
     # via edx-enterprise-data
-faker==13.4.0
+faker==13.14.0
     # via factory-boy
 freezegun==1.2.1
     # via -r requirements/test.in
@@ -154,7 +161,7 @@ html5lib==1.1
     # via -r requirements/base.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via markdown
 inflection==0.5.1
     # via drf-yasg
@@ -164,23 +171,23 @@ isort==4.3.21
     # via pylint
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   coreschema
     #   diff-cover
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
 lazy-object-proxy==1.4.3
     # via astroid
-markdown==3.3.6
+markdown==3.3.7
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via pylint
-newrelic==7.10.0.175
+newrelic==7.12.0.176
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in
@@ -188,13 +195,13 @@ packaging==21.3
     # via
     #   drf-yasg
     #   pytest
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
 pluggy==1.0.0
     # via
     #   diff-cover
     #   pytest
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 py==1.11.0
     # via pytest
@@ -202,7 +209,7 @@ pycodestyle==2.8.0
     # via -r requirements/test.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pydocstyle==6.1.1
     # via -r requirements/test.in
@@ -210,7 +217,7 @@ pygments==2.12.0
     # via diff-cover
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
@@ -221,7 +228,9 @@ pylint==2.4.4
     #   -r requirements/test.in
 pymongo==3.12.3
     # via edx-opaque-keys
-pyparsing==3.0.8
+pynacl==1.5.0
+    # via edx-django-utils
+pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
     # via
@@ -247,7 +256,7 @@ pytz==2022.1
     #   djangorestframework
 pyyaml==6.0
     # via edx-django-release-util
-requests==2.27.1
+requests==2.28.0
     # via
     #   coreapi
     #   edx-drf-extensions
@@ -256,7 +265,7 @@ requests==2.27.1
     #   pyjwkest
     #   responses
     #   slumber
-responses==0.20.0
+responses==0.21.0
     # via -r requirements/test.in
 ruamel-yaml==0.17.21
     # via drf-yasg
@@ -264,9 +273,9 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 rules==3.3
     # via edx-enterprise-data
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.16.0
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.4
     # via virtualenv
-filelock==3.6.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -18,7 +18,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 six==1.16.0
     # via
@@ -32,5 +32,5 @@ tox==3.25.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/tox.in
-virtualenv==20.14.1
+virtualenv==20.15.0
     # via tox


### PR DESCRIPTION
Automated upgrade failed but local upgrade works when I expected it to fail in the same way, might as well take the upgrade results.

I suspect this upgrade PR will get us past the problematic pip versions.