### PR TITLE
build: remove unnecessary codecov dependency

### DIFF
--- a/docs/api/source/conf.py
+++ b/docs/api/source/conf.py
@@ -4,7 +4,6 @@ import django
 
 from path import Path
 
-import edx_theme
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path.append('source/_templates')
@@ -32,7 +31,6 @@ django.setup()
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'edx_theme',
     'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx',
     'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath',
     'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
@@ -42,20 +40,50 @@ extensions = [
 exclude_patterns = ['build', 'links.rst']
 
 project = 'Open edX Data Analytics API'
-copyright = '2021, edX'
+copyright = '2021, Axim Collaborative, Inc'
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+ "repository_url": "https://github.com/openedx/edx-analytics-data-api",
+ "repository_branch": "master",
+ "path_to_docs": "docs/api/source",
+ "home_page_in_toc": True,
+ "use_repository_button": True,
+ "use_issues_button": True,
+ "use_edit_page_button": True,
+ # Please don't change unless you know what you're doing.
+ "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [edx_theme.get_html_theme_path()]
+# html_theme_path = []

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,4 +2,3 @@
 
 -c constraints.txt
 
-codecov

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-codecov==2.1.13
-    # via -r requirements/ci.in
 coverage==7.2.3
     # via codecov
 idna==3.4

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,4 +4,4 @@
 
 Sphinx                              # Developer documentation builder
 path
-edx_sphinx_theme
+sphinx-book-theme

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 asgiref==3.6.0
@@ -11,7 +13,11 @@ asgiref==3.6.0
     #   django
     #   django-countries
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.0
+    # via pydata-sphinx-theme
 boto==2.49.0
     # via -r requirements/base.in
 boto3==1.26.115
@@ -96,7 +102,9 @@ djangorestframework==3.14.0
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
 docutils==0.19
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.5
@@ -132,8 +140,6 @@ edx-rest-api-client==5.5.0
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 factory-boy==3.2.1
     # via edx-enterprise-data
 faker==18.4.0
@@ -173,6 +179,7 @@ ordered-set==4.1.0
 packaging==23.1
     # via
     #   drf-yasg
+    #   pydata-sphinx-theme
     #   sphinx
 path==16.6.0
     # via -r requirements/doc.in
@@ -184,8 +191,13 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.17
     # via pyjwkest
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.0
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
 pyjwt[crypto]==2.6.0
@@ -238,7 +250,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-rbac
-    #   edx-sphinx-theme
     #   html5lib
     #   pyjwkest
     #   python-dateutil
@@ -247,10 +258,15 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -272,7 +288,9 @@ stevedore==5.0.0
 tqdm==4.65.0
     # via -r requirements/base.in
 typing-extensions==4.5.0
-    # via django-countries
+    # via
+    #   django-countries
+    #   pydata-sphinx-theme
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1


### PR DESCRIPTION
On Wednesday this happened with Codecov: https://about.codecov.io/blog/message-regarding-the-pypi-package/

Since codecov's GHA-based uploader doesn't depend on this package, this PR removes it.