### PR TITLE
fix: install pkg-config dependency for mysqlclient>=2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:focal as base
 
 # System requirements.
+
+# pkg-config; mysqlclient>=2.2.0 requires pkg-config (https://github.com/PyMySQL/mysqlclient/issues/620)
+
 RUN apt update && \
-  apt-get install -qy \ 
+  DEBIAN_FRONTEND=noninteractive apt-get install -qy \ 
   curl \
   vim \
   language-pack-en \
@@ -11,6 +14,7 @@ RUN apt update && \
   python3-virtualenv \
   python3.8-distutils \
   libmysqlclient-dev \
+  pkg-config \
   libssl-dev && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**JIRA:** None.

**Description:**

Repositiories that depend on mysqlclient>=2.2.0 will need to install the package pkg-config in their Dockerfile: https://github.com/PyMySQL/mysqlclient/issues/620. This commit installs the pkg-config package in the Dockerfile.

If this is missing, then pip install of mysqlclient fails with an error that includes the following:

```
Exception: Can not find valid pkg-config name.
Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually
```

See https://github.com/edx/edx-arch-experiments/issues/349.

**Author concerns:** None.

**Dependencies:** None.

**Installation instructions:** None.

**Testing instructions:**

Build the Dockerfile using `docker build -f Dockerfile .`.