### PR TITLE
fix: remove tox-battery from requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,9 +13,9 @@ backports-zoneinfo==0.2.1
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.33.7
+boto3==1.33.10
     # via -r requirements/base.in
-botocore==1.33.7
+botocore==1.33.10
     # via
     #   boto3
     #   s3transfer
@@ -107,7 +107,7 @@ edx-django-utils==5.9.0
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
-edx-drf-extensions==9.0.0
+edx-drf-extensions==9.0.1
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
@@ -150,7 +150,7 @@ markdown==3.5.1
     # via -r requirements/base.in
 markupsafe==2.1.3
     # via jinja2
-newrelic==9.2.0
+newrelic==9.3.0
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,7 +24,3 @@ elasticsearch-dsl>=7.2.1,<8.0.0
 # Use same version of edx-lint
 pylint==2.4.4
 pylint-django==2.0.11
-
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,9 +13,9 @@ backports-zoneinfo==0.2.1
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.33.7
+boto3==1.33.10
     # via -r requirements/base.in
-botocore==1.33.7
+botocore==1.33.10
     # via
     #   boto3
     #   s3transfer
@@ -107,7 +107,7 @@ edx-django-utils==5.9.0
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
-edx-drf-extensions==9.0.0
+edx-drf-extensions==9.0.1
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
@@ -152,7 +152,7 @@ markupsafe==2.1.3
     # via jinja2
 mysqlclient==2.2.0
     # via -r requirements/dev.in
-newrelic==9.2.0
+newrelic==9.3.0
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,9 +23,9 @@ beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.33.7
+boto3==1.33.10
     # via -r requirements/base.in
-botocore==1.33.7
+botocore==1.33.10
     # via
     #   boto3
     #   s3transfer
@@ -121,7 +121,7 @@ edx-django-utils==5.9.0
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
-edx-drf-extensions==9.0.0
+edx-drf-extensions==9.0.1
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
@@ -170,7 +170,7 @@ markdown==3.5.1
     # via -r requirements/base.in
 markupsafe==2.1.3
     # via jinja2
-newrelic==9.2.0
+newrelic==9.3.0
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -13,9 +13,9 @@ backports-zoneinfo==0.2.1
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.33.7
+boto3==1.33.10
     # via -r requirements/base.in
-botocore==1.33.7
+botocore==1.33.10
     # via
     #   boto3
     #   s3transfer
@@ -107,7 +107,7 @@ edx-django-utils==5.9.0
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
-edx-drf-extensions==9.0.0
+edx-drf-extensions==9.0.1
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
@@ -158,7 +158,7 @@ markupsafe==2.1.3
     # via jinja2
 mysqlclient==2.2.0
     # via -r requirements/production.in
-newrelic==9.2.0
+newrelic==9.3.0
     # via
     #   -r requirements/production.in
     #   edx-django-utils

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,9 +15,9 @@ backports-zoneinfo==0.2.1
     # via django
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.33.7
+boto3==1.33.10
     # via -r requirements/base.in
-botocore==1.33.7
+botocore==1.33.10
     # via
     #   boto3
     #   s3transfer
@@ -120,7 +120,7 @@ edx-django-utils==5.9.0
     #   edx-drf-extensions
     #   edx-enterprise-data
     #   edx-rest-api-client
-edx-drf-extensions==9.0.0
+edx-drf-extensions==9.0.1
     # via
     #   -r requirements/base.in
     #   edx-enterprise-data
@@ -177,7 +177,7 @@ markupsafe==2.1.3
     # via jinja2
 mccabe==0.6.1
     # via pylint
-newrelic==9.2.0
+newrelic==9.3.0
     # via edx-django-utils
 ordered-set==4.1.0
     # via -r requirements/base.in

--- a/requirements/tox.in
+++ b/requirements/tox.in
@@ -2,4 +2,3 @@
 -c constraints.txt
 
 tox
-tox-battery

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -11,23 +17,22 @@ filelock==3.13.1
     #   tox
     #   virtualenv
 packaging==23.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 platformdirs==4.1.0
-    # via virtualenv
+    # via
+    #   tox
+    #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/tox.in
-    #   tox-battery
-tox-battery==0.6.2
+    #   pyproject-api
+    #   tox
+tox==4.11.4
     # via -r requirements/tox.in
 virtualenv==20.25.0
     # via tox


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements since it is not needed for `tox v4`.
- Updated `tox` to `v4`.